### PR TITLE
Use `single` output instead of `static`. 

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,7 +19,7 @@
     },
     "web": {
       "bundler": "metro",
-      "output": "static",
+      "output": "single",
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [


### PR DESCRIPTION
`expo-blur` and `@expo/vector-icons` are having issues changing color based off the `useColorScheme()` theme value. This does not repro locally when running metro server. 